### PR TITLE
position제대로 표시안되던 문제 해결

### DIFF
--- a/template/js/view/schedule/schedule-display.js
+++ b/template/js/view/schedule/schedule-display.js
@@ -30,7 +30,7 @@ ScheduleDisplay.prototype = {
             for (var j = 0; j < schedules.length; j++) {
                 this.schedule = schedules[j];
                 this.status.position = j;
-                if (this.schedule.length === 0) continue;
+                if (this.schedule.length === 0) continue; //빈 객체가 포함되어 있으면 이벤트출력 안함
                 if (this.schedule.repeat !== "none") {
                     this.repeatEvent(this.schedule);
                     this.initRow++;
@@ -117,7 +117,7 @@ ScheduleDisplay.prototype = {
 
         eventLink.setAttribute("data-key", this.status.key);
         eventLink.setAttribute("data-pos", this.status.position);
-        console.log(this.status.key, this.status.position);
+
         if (ele.isEqualNode(ele.parentNode.firstElementChild) || this.status.isStart) {
             eventLink._$("div").innerHTML = "<span class = \"fc-title\">" + title + "</span>";
         }
@@ -136,28 +136,23 @@ ScheduleDisplay.prototype = {
     getThisMonthEvent: function() {
         for (var i = 0; i < localStorage.length; i++) {
             var key = localStorage.key(i);
-            var due = key.split("S");
-            var eStart = due[0];
-            var eEnd = due[1].replace("E", "");
             var items = localStorage.getItem(key);
-            // 지난달과 이번달에 해당하는 repeatEvent를 받아온다
-            var schedules = JSON.parse(localStorage.getItem(key));
+            var schedules = JSON.parse(items);
+            var order = []; // 이번달에 표시할 이벤트
+            var isRepeat = this.isRepeatEvent(key);
 
-            var order = [];
-            var isRepeat = this.isRepeatEvent(key, eStart, eEnd);
             if (isRepeat[0] || isRepeat[1].length > 0) order = isRepeat[1];
-
             if (order.length > 0) {
-                var temp = [];
+                var _schedules = [];
                 for (var j = 0; j < schedules.length; j++) {
                     var schedule = schedules[j];
                     if (order.indexOf(j) !== -1) {
-                        temp.push(JSON.stringify(schedule));
+                        _schedules.push(JSON.stringify(schedule));
                     } else {
-                        temp.push("{}");
+                        _schedules.push("{}");
                     }
                 }
-                this.scheduleObjects.push("[" + temp + "]");
+                this.scheduleObjects.push("[" + _schedules + "]");
                 this.keys.push(key);
                 continue;
             }
@@ -167,16 +162,15 @@ ScheduleDisplay.prototype = {
             }
         }
     },
-    isRepeatEvent: function(key, eStart, eEnd) {
+    isRepeatEvent: function(key) {
         var order = []; // 이번달에 표시할 이벤트
         var count = 0;
         var schedules = JSON.parse(localStorage.getItem(key));
+
         for (var i = 0; i < schedules.length; i++) {
             var schedule = schedules[i];
             if (schedule.repeat !== "none") {
                 order.push(i);
-                // this.scheduleObjects.push("[" + JSON.stringify(schedule) + "]");
-                // this.keys.push(key);
                 count++;
             } else {
                 if(this.checkThisMonth(key)) order.push(i);

--- a/template/js/view/schedule/schedule-display.js
+++ b/template/js/view/schedule/schedule-display.js
@@ -5,7 +5,6 @@ function ScheduleDisplay() {
     this.status;
 }
 ScheduleDisplay.prototype = {
-
     init: function(calendar, due, type) {
         //TODO:due와 type 이용해 일정 기간 스케쥴들 가져오는 함수 추가해야함
         // TODO: data.js에 저장해 둔 일정을 불러오는 형식으로 변경할 것.
@@ -24,7 +23,6 @@ ScheduleDisplay.prototype = {
         };
         this.initRow = 0;
     },
-
     setEvents: function() {
         for (var i = 0; i < this.scheduleObjects.length; i++) {
             var schedules = JSON.parse(this.scheduleObjects[i]);
@@ -32,11 +30,11 @@ ScheduleDisplay.prototype = {
             for (var j = 0; j < schedules.length; j++) {
                 this.schedule = schedules[j];
                 this.status.position = j;
-                if(this.schedule.length === 0) continue;
+                if (this.schedule.length === 0) continue;
                 if (this.schedule.repeat !== "none") {
                     this.repeatEvent(this.schedule);
                     this.initRow++;
-                } else  {
+                } else {
                     this.setMonthEvent(this.schedule);
                 }
             }
@@ -82,7 +80,6 @@ ScheduleDisplay.prototype = {
             }
         }
     },
-
     initStatus: function() {
         var start = Utility.setTimeByGMT(new Date(this.schedule.start));
         var end = Utility.setTimeByGMT(new Date(this.schedule.end));
@@ -100,9 +97,7 @@ ScheduleDisplay.prototype = {
         this.status.isEnd = false;
         this.status.row = this.initRow;
     },
-
     setBarStatus: function(status) {
-
         if (status.isStart) {
             status.isStart = false;
         }
@@ -113,7 +108,6 @@ ScheduleDisplay.prototype = {
             status.remain--;
         }
     },
-
     setEventBar: function(ele, title) {
         Utility.addClass(ele, "fc-event-container");
         ele.innerHTML = "<a class = \"fc-day-grid-event fc-h-event fc-event fc-draggable fc-resizable\">" +
@@ -139,7 +133,6 @@ ScheduleDisplay.prototype = {
             Utility.addClass(eventLink, "fc-not-end");
         }
     },
-
     getThisMonthEvent: function() {
         for (var i = 0; i < localStorage.length; i++) {
             var key = localStorage.key(i);
@@ -154,13 +147,13 @@ ScheduleDisplay.prototype = {
             var isRepeat = this.isRepeatEvent(key, eStart, eEnd);
             if (isRepeat[0] || isRepeat[1].length > 0) order = isRepeat[1];
 
-            if(order.length > 0) {
+            if (order.length > 0) {
                 var temp = [];
-                for(var j=0; j< schedules.length; j++) {
+                for (var j = 0; j < schedules.length; j++) {
                     var schedule = schedules[j];
-                    if(order.indexOf(j) !== -1) {
+                    if (order.indexOf(j) !== -1) {
                         temp.push(JSON.stringify(schedule));
-                    }else {
+                    } else {
                         temp.push("{}");
                     }
                 }
@@ -168,18 +161,7 @@ ScheduleDisplay.prototype = {
                 this.keys.push(key);
                 continue;
             }
-
-            if (eEnd < this.calendar.lastDay) {
-                if (eEnd > this.calendar.firstDay) {
-                    this.scheduleObjects.push(items);
-                    this.keys.push(key);
-                }
-            } else if (eStart > this.calendar.firstDay) {
-                if (eStart < this.calendar.lastDay) {
-                    this.scheduleObjects.push(items);
-                    this.keys.push(key);
-                }
-            } else {
+            if(this.checkThisMonth(key)) {
                 this.scheduleObjects.push(items);
                 this.keys.push(key);
             }
@@ -197,21 +179,30 @@ ScheduleDisplay.prototype = {
                 // this.keys.push(key);
                 count++;
             } else {
-                if (eEnd < this.calendar.lastDay) {
-                    if (eEnd > this.calendar.firstDay) {
-                        order.push(i);
-                    }
-                } else if (eStart > this.calendar.firstDay) {
-                    if (eStart < this.calendar.lastDay) {
-                        order.push(i);
-                    }
-                } else {
-                    order.push(i);
-                }
+                if(this.checkThisMonth(key)) order.push(i);
             }
         }
         if (count === schedules.length) return [true, []];
         else return [false, order];
+    },
+    checkThisMonth: function(key) {
+        var result = false;
+        var due = key.split("S");
+        var eStart = due[0];
+        var eEnd = due[1].replace("E", "");
+
+        if (eEnd < this.calendar.lastDay) {
+            if (eEnd > this.calendar.firstDay) {
+                result = true;
+            }
+        } else if (eStart > this.calendar.firstDay) {
+            if (eStart < this.calendar.lastDay) {
+                result = true;
+            }
+        } else {
+            result = true;
+        }
+        return result;
     },
     repeatEvent: function(event) {
         var repeatType = event.repeat;

--- a/template/js/view/schedule/schedule-display.js
+++ b/template/js/view/schedule/schedule-display.js
@@ -176,7 +176,7 @@ ScheduleDisplay.prototype = {
                 if(this.checkThisMonth(key)) order.push(i);
             }
         }
-        if (count === schedules.length) return [true, []];
+        if (count === schedules.length) return [true, order];
         else return [false, order];
     },
     checkThisMonth: function(key) {


### PR DESCRIPTION
getThisMonthEvent에서 한 key에 반복일정과 일반일정이 섞여있을때, 일반일정이 달력에 표시되지 않아도 빈 객체 {}로 삽입하여 position을 올바르게 잡을 수 있도록 했습니다.
그리고 setEvent함수에서 만약 schedule이 {}로 비어있으면 출력하지 않게 했습니다.

(+)
이벤트가 이번달에 포함하는지 판단하는 부분을 여러번 사용하게되어 함수로 분리했습니다.
checkThisMonth(key)로 key값을 전달하면 해당 key값의 시작날짜와 끝날짜를 추출하여 이벤트가 현재 달력에 포함되는지 판단하여 T/F로 반환합니다.