### PR TITLE
반복일정 달력 끝에 걸치는 경우 나타나지 않는 오류 해결

### DIFF
--- a/template/js/lib/util.js
+++ b/template/js/lib/util.js
@@ -111,7 +111,7 @@ var Utility = {
         }
     },
     setTimeByGMT: function(date) {
-      var converted = date;
+      var converted = new Date(date);
       var offset = date.getTimezoneOffset()/60;
       var hours = date.getHours();
 

--- a/template/js/view/calendar/mini-calendar.js
+++ b/template/js/view/calendar/mini-calendar.js
@@ -80,12 +80,15 @@ MiniCalendar.prototype = {
     getEvent: function(events) {
         var result = [];
         var startDate = this.callbackList['GET_NUMS'](this.myDate)[1];
+        var endDate = this.callbackList['GET_NUMS'](this.myDate)[2];
         for (var i = 0; i < events.length; i++) {
             var eventArray = JSON.parse(events[i]);
             for (var j = 0; j < eventArray.length; j++) {
                 event = eventArray[j];
                 if (event.repeat === 'none' ||
                     event.start > startDate) { // 반복일정이 아니면 해당 달에 존재하므로 추가
+                    result.push(event);
+                } else if (event.end > startDate){
                     result.push(event);
                 }
             }

--- a/template/js/view/schedule/schedule-display.js
+++ b/template/js/view/schedule/schedule-display.js
@@ -253,7 +253,7 @@ ScheduleDisplay.prototype = {
         var first = Utility.setTimeByGMT(new Date(this.calendar.firstDay));
         Utility.setTimeDefault(first, 0);
 
-        while (first >= nextStart) {
+        while (first > nextEnd) {
             this.moveNextRepeatEvent(nextStart, nextEnd, repeatType);
         }
     },

--- a/template/js/view/schedule/schedule-display.js
+++ b/template/js/view/schedule/schedule-display.js
@@ -244,7 +244,7 @@ ScheduleDisplay.prototype = {
 
         var last = Utility.setTimeByGMT(new Date(this.calendar.lastDay));
         Utility.setTimeDefault(last, 9);
-        while (last >= nextEnd) {
+        while (last >= Utility.setTimeByGMT(nextEnd)) {
             this.showRepeatEvent(event, nextStart, nextEnd);
             this.moveNextRepeatEvent(nextStart, nextEnd, repeatType);
         }

--- a/template/js/view/schedule/schedule-display.js
+++ b/template/js/view/schedule/schedule-display.js
@@ -244,7 +244,7 @@ ScheduleDisplay.prototype = {
 
         var last = Utility.setTimeByGMT(new Date(this.calendar.lastDay));
         Utility.setTimeDefault(last, 9);
-        while (last >= Utility.setTimeByGMT(nextEnd)) {
+        while (last >= Utility.setTimeByGMT(nextStart)) {
             this.showRepeatEvent(event, nextStart, nextEnd);
             this.moveNextRepeatEvent(nextStart, nextEnd, repeatType);
         }


### PR DESCRIPTION
#160 
* End날짜를 GMT로 변환하여 끝날짜랑 비교
* 반환값과 원본을 따로하기 위해 util.js 수정


